### PR TITLE
Ram itinerary provider

### DIFF
--- a/scripts/itinerary/ItineraryProvider.js
+++ b/scripts/itinerary/ItineraryProvider.js
@@ -1,11 +1,12 @@
 let itinerariesCollection = []
 
-const useItineraries = () => [...itinerariesCollection]
+export const useItineraries = () => [...itinerariesCollection]
 
 export const getItineraries = () => {
-    fetch("http://localhost:8088")
+    return fetch("http://localhost:8088/itineraries")
         .then( res => res.json() )
         .then( parsedRes => {
-            itinerariesCollection = useItineraries()
-        })
+                itinerariesCollection = parsedRes
+                console.log(itinerariesCollection)
+            })
 }

--- a/scripts/itinerary/ItineraryProvider.js
+++ b/scripts/itinerary/ItineraryProvider.js
@@ -1,0 +1,11 @@
+let itinerariesCollection = []
+
+const useItineraries = () => [...itinerariesCollection]
+
+export const getItineraries = () => {
+    fetch("http://localhost:8088")
+        .then( res => res.json() )
+        .then( parsedRes => {
+            itinerariesCollection = useItineraries()
+        })
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,7 @@
 import { getParks, useParks } from "./parks/ParkProvider.js";
 import { settings } from "./Settings.js";
 import { getEateries } from './eateries/EateryProvider.js'
+import { getItineraries, useItineraries } from "./itinerary/ItineraryProvider.js";
 
 let allParks = []
 getParks(settings.npsKey)
@@ -11,3 +12,4 @@ getParks(settings.npsKey)
 
 getEateries()
 
+getItineraries()


### PR DESCRIPTION
# Description

Adds the Itinerary Provider

Fixes # not having that. 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions

```
git fetch --all
git checkout ram-itinerary-provider
serve
```
Serve API

Replace your db.json with this code:
```
{
	"itineraries": [
		{
			"name": "Alex",
			"age": "30"
		},
		{
			"name": "Anna",
			"age": "32"
		}
	]
}

```

Refresh the page.

# Checklist:

- [ ] Those two objects appear in the console