### PR TITLE
fixed bug where dom would render old selections after saving when a n…

### DIFF
--- a/scripts/preview/PreviewList.js
+++ b/scripts/preview/PreviewList.js
@@ -106,6 +106,9 @@ const resetPage = () => {
     })
 }
 const clearPreview = () => {
+    parkHTML = ""
+    eateryHTML = ""
+    attractionHTML = ""
     parkObj = {}
     eateryObj = {}
     attractionObj = {}


### PR DESCRIPTION
…ew selection was made by setting the html strings to empty strings when the clearpreview function is called

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions

Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests

save an itinerary and then select something new from the dropdown should only show your new selection on the dom

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
